### PR TITLE
Make setMemory require segments array (even if empty)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -325,7 +325,7 @@ declare module binaryen {
     addGlobalExport(internalName: string, externalName: string): Export;
     removeExport(externalName: string): void;
     setFunctionTable(funcs: number[]): void;
-    setMemory(initial: number, maximum: number, exportName?: string, segments?: MemorySegment[]): void;
+    setMemory(initial: number, maximum: number, exportName: string|null, segments: MemorySegment[]): void;
     setStart(start: binaryen.Function): void;
 
     emitBinary(): Uint8Array;


### PR DESCRIPTION
The current type signature says that segments is optional, but [it unfortunately isn't currently](https://github.com/WebAssembly/binaryen/blob/master/src/js/binaryen.js-post.js#L1094-L1117). (produces segments.map errors).

This is a bit of an awkward type signature since indeed the [exportName has to be optional because it being provided means it should be exported](https://github.com/WebAssembly/binaryen/blob/94cbe63149248e251580ef95a6d3a31faf00a238/src/binaryen-c.cpp#L1178).

It's possible the ideal solution is to [make segments optional](https://github.com/WebAssembly/binaryen/blob/master/src/js/binaryen.js-post.js#L1094-L1117), but until that time I figured this was easy enough to correct.

The README has the correct signature already. Though because JavaScript is so awesome the signature `string|null|undefined` might be more flexible. Your call, I can change the README.

***

* Module#**setMemory**(initial: `number`, maximum: `number`, exportName: `string | null`, segments: `MemorySegment[]`): `void`<br />
  Sets the memory. There's just one memory for now, using name `"0"`. Providing `exportName` also creates a memory export.