### PR TITLE
Add missing members to getGlobalInfo API

### DIFF
--- a/API.md
+++ b/API.md
@@ -164,6 +164,8 @@ The API is documented in the rest of this document.
   * GlobalInfo#**module**: `string | null` (if imported)
   * GlobalInfo#**base**: `string | null` (if imported)
   * GlobalInfo#**type**: `Type`
+  * GlobalInfo#**mutable**: `boolean`
+  * GlobalInfo#**init**: `Expression`
 
 * **getExportInfo**(export_: `Export`): `ExportInfo`<br />
   Obtains information about an export.


### PR DESCRIPTION
This adds missing members to getGlobalInfo API, to sync with
WebAssembly/binaryen#2099.