### PR TITLE
Add getGlobal and removeGlobal to API.md

### DIFF
--- a/API.md
+++ b/API.md
@@ -123,6 +123,12 @@ The API is documented in the rest of this document.
 * Module#**addGlobal**(name: `string`, type: `Type`, mutable: `number`, value: `Expression`): `Global`<br />
   Adds a global instance variable.
 
+* Module#**getGlobal**(name: `string`): `Global`<br />
+  Gets a global, by name,
+
+* Module#**removeGlobal**(name: `string`): `void`<br />
+  Removes a global, by name.
+
 * Module#**removeExport**(externalName: `string`): `void`<br />
   Removes an export, by external name.
 


### PR DESCRIPTION
`getGlobal` was missing in Binaryen (because of its name clashed with
deprecated `get_global` instruction), but added in
WebAssembly/binaryen#2142 after instruction renaming. `removeGlobal` has
been there but it was not listed here.