### PR TITLE
Update declarations related to tail calls

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1456,11 +1456,13 @@ declare module binaryen {
   }
 
   interface CallInfo extends ExpressionInfo {
+    isReturn: boolean;
     target: string;
     operands: ExpressionRef[];
   }
 
   interface CallIndirectInfo extends ExpressionInfo {
+    isReturn: boolean;
     target: ExpressionRef;
     operands: ExpressionRef[];
   }


### PR DESCRIPTION
This PR updates some declarations related to tail calls:

* `CallInfo`/`CallIndirectInfo` now contains an extra `isReturn` boolean field
* The `return_call`/`return_call_indirect` methods are actually non-existent in `binaryen.Module`; the methods available are `returnCall`/`returnCallIndirect`, thus the renaming