### PR TITLE
Document Module#br command and add Module#break to index.d.ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,9 +445,12 @@ API
 
 * Module#**loop**(label: `string | null`, body: `ExpressionRef`): `ExpressionRef`<br />
   Creates a loop.
+  
+* Module#**br**(label: `string`, condition?: `ExpressionRef`, value?: `ExpressionRef`): `ExpressionRef`<br />
+  Creates a branch to a label.
 
 * Module#**break**(label: `string`, condition?: `ExpressionRef`, value?: `ExpressionRef`): `ExpressionRef`<br />
-  Creates a break (br) to a label.
+  Alias for br.
 
 * Module#**switch**(labels: `string[]`, defaultLabel: `string`, condition: `ExpressionRef`, value?: `ExpressionRef`): `ExpressionRef`<br />
   Creates a switch (br_table).

--- a/README.md
+++ b/README.md
@@ -447,10 +447,10 @@ API
   Creates a loop.
   
 * Module#**br**(label: `string`, condition?: `ExpressionRef`, value?: `ExpressionRef`): `ExpressionRef`<br />
-  Creates a branch to a label.
+  Creates a branch (br) to a label.
 
 * Module#**break**(label: `string`, condition?: `ExpressionRef`, value?: `ExpressionRef`): `ExpressionRef`<br />
-  Alias for br.
+  Alias for Module#br.
 
 * Module#**switch**(labels: `string[]`, defaultLabel: `string`, condition: `ExpressionRef`, value?: `ExpressionRef`): `ExpressionRef`<br />
   Creates a switch (br_table).

--- a/README.md
+++ b/README.md
@@ -449,9 +449,6 @@ API
 * Module#**br**(label: `string`, condition?: `ExpressionRef`, value?: `ExpressionRef`): `ExpressionRef`<br />
   Creates a branch (br) to a label.
 
-* Module#**break**(label: `string`, condition?: `ExpressionRef`, value?: `ExpressionRef`): `ExpressionRef`<br />
-  Alias for Module#br.
-
 * Module#**switch**(labels: `string[]`, defaultLabel: `string`, condition: `ExpressionRef`, value?: `ExpressionRef`): `ExpressionRef`<br />
   Creates a switch (br_table).
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -806,7 +806,6 @@ declare module binaryen {
     block(label: string, children: ExpressionRef[], resultType?: Type): ExpressionRef;
     if(condition: ExpressionRef, ifTrue: ExpressionRef, ifFalse?: ExpressionRef): ExpressionRef;
     loop(label: string, body: ExpressionRef): ExpressionRef;
-    break(label: string, condition?: ExpressionRef, value?: ExpressionRef): ExpressionRef;
     br(label: string, condition?: ExpressionRef, value?: ExpressionRef): ExpressionRef;
     br_if(label: string, condition?: ExpressionRef, value?: ExpressionRef): ExpressionRef;
     switch(labels: string[], defaultLabel: string, condition: ExpressionRef, value?: ExpressionRef): ExpressionRef;

--- a/index.d.ts
+++ b/index.d.ts
@@ -806,6 +806,7 @@ declare module binaryen {
     block(label: string, children: ExpressionRef[], resultType?: Type): ExpressionRef;
     if(condition: ExpressionRef, ifTrue: ExpressionRef, ifFalse?: ExpressionRef): ExpressionRef;
     loop(label: string, body: ExpressionRef): ExpressionRef;
+    break(label: string, condition?: ExpressionRef, value?: ExpressionRef): ExpressionRef;
     br(label: string, condition?: ExpressionRef, value?: ExpressionRef): ExpressionRef;
     br_if(label: string, condition?: ExpressionRef, value?: ExpressionRef): ExpressionRef;
     switch(labels: string[], defaultLabel: string, condition: ExpressionRef, value?: ExpressionRef): ExpressionRef;


### PR DESCRIPTION
Hey! I noticed that **Module#break** wasn't in the index.d.ts file. So I went ahead and corrected index.d.ts. I also updated the README to document the **Module#br** alias.

One question though, should Module#break be included at all? I'm new to WASM, so I assumed it would behave like a normal break, which turned out not to be the case. Isn't `br` more accurate? Since its not really `break`ing (depending on the block it points to anyway). 

If so, I'd be happy to update the pull request to reflect that.