### PR TITLE
Add reference types support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1203,6 +1203,12 @@ Note that these are pseudo instructions enabling Binaryen to reason about multip
   * TryInfo#**body**: `ExpressionRef`
   * TryInfo#**catchBody**: `ExpressionRef`
   >
+  * RefNullInfo
+  >
+  * RefIsNullInfo#**value**: `ExpressionRef`
+  >
+  * RefFuncInfo#**func**: `string`
+  >
   * ThrowInfo#**event**: `string`
   * ThrowInfo#**operands**: `ExpressionRef[]`
   >

--- a/index.d.ts
+++ b/index.d.ts
@@ -1640,6 +1640,17 @@ declare module binaryen {
     size: ExpressionRef;
   }
 
+  interface RefNullInfo extends ExpressionInfo {
+  }
+
+  interface RefIsNullInfo extends ExpressionInfo {
+    value: ExpressionRef;
+  }
+
+  interface RefFuncInfo extends ExpressionInfo {
+    func: string;
+  }
+
   interface TryInfo extends ExpressionInfo {
     body: ExpressionRef;
     catchBody: ExpressionRef;


### PR DESCRIPTION
Add missing `RefNullInfo`, `RefIsNullInfo`, `RefFuncInfo`.

Related upstream reference types support PR: https://github.com/WebAssembly/binaryen/pull/2451