### PR TITLE
Fix the TypeScript Features Enum

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -138,18 +138,20 @@ declare module binaryen {
   const ExternalEvent: ExternalKinds;
 
   const enum Features {
-    MVP,
-    Atomics,
-    BulkMemory,
-    MutableGlobals,
-    NontrappingFPToInt,
-    SignExt,
-    SIMD128,
-    ExceptionHandling,
-    TailCall,
-    ReferenceTypes,
-    Multivalue,
-    All
+    MVP = 0,
+    Atomics = 1 << 0,
+    MutableGlobals = 1 << 1,
+    TruncSat = 1 << 2,
+    SIMD = 1 << 3,
+    BulkMemory = 1 << 4,
+    SignExt = 1 << 5,
+    ExceptionHandling = 1 << 6,
+    TailCall = 1 << 7,
+    ReferenceTypes = 1 << 8,
+    Multivalue = 1 << 9,
+    GC = 1 << 10,
+    Memory64 = 1 << 11,
+    All = (1 << 12) - 1
   }
 
   const enum Operations {

--- a/index.d.ts
+++ b/index.d.ts
@@ -137,21 +137,21 @@ declare module binaryen {
   const ExternalGlobal: ExternalKinds;
   const ExternalEvent: ExternalKinds;
 
-  const enum Features {
-    MVP = 0,
-    Atomics = 1 << 0,
-    MutableGlobals = 1 << 1,
-    TruncSat = 1 << 2,
-    SIMD = 1 << 3,
-    BulkMemory = 1 << 4,
-    SignExt = 1 << 5,
-    ExceptionHandling = 1 << 6,
-    TailCall = 1 << 7,
-    ReferenceTypes = 1 << 8,
-    Multivalue = 1 << 9,
-    GC = 1 << 10,
-    Memory64 = 1 << 11,
-    All = (1 << 12) - 1
+  enum Features {
+    MVP,
+    Atomics,
+    MutableGlobals,
+    TruncSat,
+    SIMD,
+    BulkMemory,
+    SignExt,
+    ExceptionHandling,
+    TailCall,
+    ReferenceTypes,
+    Multivalue,
+    GC,
+    Memory64,
+    All
   }
 
   const enum Operations {


### PR DESCRIPTION
Adds missing features and corrects their numeric value.

I noticed that calling `mod.setFeature` with `binaryen.Features.Multivalue` was not enabling the multi-value feature, causing binaryen to spit out an error on validate.

After some quick investigating I realized it was because the numeric value they were automatically getting set to did not
align with what the binaryen source code expected.

So I corrected their values based on the definitions [here](https://github.com/WebAssembly/binaryen/blob/3b4cb935f83c7fabacbf61146e56dabc0d65a441/src/wasm-features.h#L26).