### PR TITLE
Add bulk memory operations to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ API
   - [Multi-value operations 🦄](#multi-value-operations-)
   - [Exception handling operations 🦄](#exception-handling-operations-)
   - [Reference types operations 🦄](#reference-types-operations-)
+  - [Bulk memory operations 🦄](#bulk-memory-operations-)
 - [Expression manipulation](#expression-manipulation)
 - [Relooper](#relooper)
 - [Source maps](#source-maps)


### PR DESCRIPTION
Again these were already in index.d.ts.
I didn't use doctoc to generate the TOC... hopefully that won't break anything?