### PR TITLE
Update submodules recursively

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
           # If not a PR, undo detached head
           git checkout "${GITHUB_REF:11}"
         fi
-        git submodule update --init --remote --merge
+        git submodule update --init --remote --merge --recursive
         cd ./binaryen
         git log -n1
         cd ..


### PR DESCRIPTION
Binaryen has a new dependency on "gtest" as a submodule, which appears to be required for the buildbot to function.