### PR TITLE
Making types visible again to TypeScript compiler.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 name: Build
 on:
   schedule:

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-declare module Binaryen {
+declare module binaryen {
 
   type Type = number;
 
@@ -2126,7 +2126,5 @@ declare module Binaryen {
     runAndDispose(expr: ExpressionRef): ExpressionRef;
   }
 }
-
-declare const binaryen: typeof Binaryen;
 
 export default binaryen;


### PR DESCRIPTION
Resolves #59 

**Note**: As I do not have intimate knowledge of the internals of this project, this PR is meant only as a suggested solution, or at least to highlight what caused the above-mentioned issue.

I basically reverted a previous change in which a constant of the same shape as the module was exported instead of the module itself, which effectively made the type declarations private. I am not sure that change is needed anymore after reverting the exporting of binaryen as a Promise.

See issue #59 for the effect of the previous change.