### PR TITLE
Increase stack size to 655360

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
         cd ./binaryen/build
         source $HOME/emsdk/emsdk_env.sh
         emcc --version
-        emcmake cmake .. -DCMAKE_BUILD_TYPE=Release
+        emcmake cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXE_LINKER_FLAGS="-sSTACK_SIZE=655360"
         emmake make -j2 binaryen_wasm
         cd ../..
         npm run bundle


### PR DESCRIPTION
This should fix AssemblyScript/assemblyscript#2682 and should work around WebAssembly/binaryen#5648. I don't know. I didn't test this.