### PR TITLE
Increase stack size to 5mb

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
         cd ./binaryen/build
         source $HOME/emsdk/emsdk_env.sh
         emcc --version
-        emcmake cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXE_LINKER_FLAGS="-sSTACK_SIZE=655360"
+        emcmake cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXE_LINKER_FLAGS="-sSTACK_SIZE=5242880"
         emmake make -j2 binaryen_wasm
         cd ../..
         npm run bundle


### PR DESCRIPTION
Apparently, 5mb used to be the default, see https://github.com/WebAssembly/binaryen/issues/5648#issuecomment-1502016316