### PR TITLE
Amend stack size to 2mb

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
         cd ./binaryen/build
         source $HOME/emsdk/emsdk_env.sh
         emcc --version
-        emcmake cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXE_LINKER_FLAGS="-sSTACK_SIZE=5242880"
+        emcmake cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXE_LINKER_FLAGS="-sSTACK_SIZE=2097152"
         emmake make -j2 binaryen_wasm
         cd ../..
         npm run bundle


### PR DESCRIPTION
Looking at the respective Emscripten change (https://github.com/emscripten-core/emscripten/pull/19043), it seems that previous stack size was 2mb, so let's use that.