### PR TITLE
Remove expired functions from documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,15 +249,6 @@ API
 * Module#**removeGlobal**(name: `string`): `void`<br />
   Removes a global, by name.
 
-* Module#**setFunctionTable**(initial: `number`, maximum: `number`, funcs: `string[]`, offset?: `ExpressionRef`): `void`<br />
-  Sets the contents of the function table. There's just one table for now, using name `"0"`.
-
-* Module#**getFunctionTable**(): `{ imported: boolean, segments: TableElement[] }`<br />
-  Gets the contents of the function table.
-
-  * TableElement#**offset**: `ExpressionRef`
-  * TableElement#**names**: `string[]`
-
 * Module#**setMemory**(initial: `number`, maximum: `number`, exportName: `string | null`, segments: `MemorySegment[]`, shared?: `boolean`): `void`<br />
   Sets the memory. There's just one memory for now, using name `"0"`. Providing `exportName` also creates a memory export.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1647,8 +1647,6 @@ declare module binaryen {
     getExport(externalName: string): ExportRef;
     getNumExports(): number;
     getExportByIndex(index: number): ExportRef;
-    setFunctionTable(initial: number, maximum: number, funcNames: number[], offset?: ExpressionRef): void;
-    getFunctionTable(): { imported: boolean, segments: TableElement[] };
     setMemory(initial: number, maximum: number, exportName?: string | null, segments?: MemorySegment[] | null, shared?: boolean, memory64?: boolean, internalName?: string): void;
     getMemorySegmentInfoByIndex(index: number): MemorySegmentInfo;
     setStart(start: FunctionRef): void;


### PR DESCRIPTION
Function `setFunctionTable` and `getFunctionTable` has already been remove, but still remain in index.d.ts and Readme, which is misleading. Remove them.