### PR TITLE
[CI] fix CI hang issue caused by node 17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
     - uses: actions/setup-node@v2
       with:
-        node-version: '17'
+        node-version: '20'
     - name: "Set up Emsdk"
       run: |
         mkdir $HOME/emsdk


### PR DESCRIPTION
Current CI fails when testing `wasm-opt`, this is caused by node-17, use node 20 can fix this issue.