### PR TITLE
Change maximum memory for binaryen.js from 2 GiB to 4 GiB

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
         cd ./binaryen/build
         source $HOME/emsdk/emsdk_env.sh
         emcc --version
-        emcmake cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXE_LINKER_FLAGS="-sSTACK_SIZE=5242880"
+        emcmake cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXE_LINKER_FLAGS="-sMAXIMUM_MEMORY=4294967296"
         emmake make -j2 binaryen_wasm
         cd ../..
         npm run bundle


### PR DESCRIPTION
This change is part of fixing AssemblyScript/assemblyscript#2810. The stack size flag has been removed, as Binaryen has updated their defaults accordingly.